### PR TITLE
Fix Bland row selection inequality

### DIFF
--- a/src/Linear/Constraints/Cassowary/AugmentedSimplex.hs
+++ b/src/Linear/Constraints/Cassowary/AugmentedSimplex.hs
@@ -91,7 +91,7 @@ blandRatioPrimal :: ( Ord k
                       -> Maybe Rational
 blandRatioPrimal var row = do
   coeff <- Map.lookup var $ ineqStdVars row
-  guard $ coeff < 0
+  guard $ coeff > 0
   return $ negate (ineqStdConst row) / coeff
 
 
@@ -254,5 +254,3 @@ simplexDualRational :: ( Ord k
                        ) => (Tableau k k, Equality k Rational)
                          -> (Tableau k k, Equality k Rational)
 simplexDualRational = simplexWith (pivotDualWith nextBasicDualRational (\a b c -> unEquStd $ substituteRational a b $ EquStd c))
-
-


### PR DESCRIPTION
According to Section 2.2 in https://github.com/athanclark/cassowary-haskell/blob/master/semantics/bland.pdf the coefficient should be strictly positive.
